### PR TITLE
added ports 4200-42020 on docker-compose.yml and itest-docker-copose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     ports:
       - "7083:8000"
       - "8083:8080"
+      - "42000-42020"
     volumes:
       - static:/var/lib/emapi/
 
@@ -73,13 +74,18 @@ services:
       - openam
       - nicsweb
     ports:
-      - "8081:80"
+      - "8085:80"
     volumes:
       - static:/var/www/html/
 
   openam:
     container_name: nics_openam_1
+<<<<<<< HEAD
+    image: taborda/nicsdev_openambase
+#    build: ../nics-openam
+=======
     image: 618209257270.dkr.ecr.us-west-2.amazonaws.com/nics/openam:latest
+>>>>>>> master
     hostname: am.nicsdev.tabordasolutions.net
     environment:
       - CATALINA_OPTS=-agentlib:jdwp=transport=dt_socket,address=8000,suspend=n,server=y
@@ -87,6 +93,11 @@ services:
       - "8000:8000"
       - "8080:8080"
       - "8443:8443"
+<<<<<<< HEAD
+#    volumes:
+#      - ~/.docker/volumes/nics/openam:/root/openam
+=======
+>>>>>>> master
     networks:
       default:
         aliases:

--- a/itest-docker-compose.yml
+++ b/itest-docker-compose.yml
@@ -18,10 +18,18 @@ services:
 
   proxy:
     container_name: nics_proxy_1
+<<<<<<< HEAD
+    image: 618209257270.dkr.ecr.us-west-2.amazonaws.com/nics/proxy:itest-configured
+    ports:
+      - "80:80"
+      - "443:443"
+      - "42000-42020:42000-42020/udp"
+=======
     image: 618209257270.dkr.ecr.us-west-2.amazonaws.com/nics/proxy:latest
     ports:
       - "80:80"
       - "443:443"
+>>>>>>> master
     volumes:
       - /var/lib/docker/volumes/nics_config/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
     networks:


### PR DESCRIPTION
This is to allow the AVL's to send information from Proxy to Emapi and to allow the rules for iptables to work. The yml file now references a new image that was pushed to ECR. The image is preconfigured with iptables.