### PR TITLE
Training Name Change and TLS Certificate

### DIFF
--- a/training-docker-compose.yml
+++ b/training-docker-compose.yml
@@ -24,10 +24,11 @@ services:
       - "443:443"
     volumes:
       - /var/lib/docker/volumes/nics_config/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
+      - /var/lib/docker/volumes/nics_config/training-certificate.pem:/usr/local/etc/haproxy/certificate.pem
     networks:
       default:
         aliases:
-          - www.scouttraining.tabordasolutions.net
+          - training.scout.ca.gov
 
   web:
     volumes:


### PR DESCRIPTION
This is from changing the dns name of the training env to training.scout.ca.gov